### PR TITLE
Plugin cleanup

### DIFF
--- a/config_files/demo/init_config.py
+++ b/config_files/demo/init_config.py
@@ -64,7 +64,7 @@ def parse_options():
                       default=False)
     parser.add_option("--seed",
                       action="store",
-                      type=int
+                      type=int,
                       default=0)
 
     # Return three-tuple of parser + the output from parse_args (opt obj, args)

--- a/config_files/demo/init_config.py
+++ b/config_files/demo/init_config.py
@@ -12,13 +12,17 @@ except ModuleNotFoundError:
 
 def mogp_configuration_initialization(sample_points,
                                       results_dir,
-                                      isSWEEP):
+                                      isSWEEP, seed=0):
 
     ed = mogp_emulator.LatinHypercubeDesign(
         [(-120., -80.), (0.1, 0.4), (0.9, 1.1)])
 
     # We can now generate a design of sample_points by calling the sample
-    np.random.seed(157374)
+
+    if seed == 0:
+        seed = None
+
+    np.random.seed(seed)
     input_points = ed.sample(sample_points)
 
     if isSWEEP == False:
@@ -58,6 +62,10 @@ def parse_options():
     parser.add_option("--isSWEEP",
                       action="store_true",
                       default=False)
+    parser.add_option("--seed",
+                      action="store",
+                      type=int
+                      default=0)
 
     # Return three-tuple of parser + the output from parse_args (opt obj, args)
     options, args = parser.parse_args()
@@ -70,4 +78,5 @@ if __name__ == "__main__":
 
     mogp_configuration_initialization(options.sample_points,
                                       options.results_dir,
-                                      options.isSWEEP)
+                                      options.isSWEEP,
+                                      options.seed)

--- a/config_files/demo/mogp_functions.py
+++ b/config_files/demo/mogp_functions.py
@@ -12,9 +12,7 @@ except ModuleNotFoundError:
     import pickle
 
 
-def run_mogp_simulation(mpi_exec, fdfault_exec, results_dir):
-
-    np.random.seed(157374)
+def run_fdfault_simulation(mpi_exec, fdfault_exec, results_dir):
 
     input_points = np.load(join(results_dir, "input_points.npy"))
 
@@ -42,9 +40,7 @@ def run_mogp_simulation(mpi_exec, fdfault_exec, results_dir):
     np.save('input_points.npy', input_points)
 
 
-def run_mogp_analysis(mpi_exec, fdfault_exec, results_dir):
-
-    np.random.seed(157374)
+def load_results(results_dir):
 
     ed = None
     input_points = []
@@ -66,60 +62,32 @@ def run_mogp_analysis(mpi_exec, fdfault_exec, results_dir):
     input_points = np.array(input_points)
     results = np.array(results)
 
-    # Now fit a Gaussian Process to the input_points and results to fit the
-    # approximate model. We use the basic maximum martinal likelihood method
-    # to estimate the GP hyperparameters
+    return input_points, results, ed
+
+def run_mogp_analysis(analysis_points, known_value, threshold, results_dir):
+
+    input_points, results, ed = load_results(results_dir)
+
+    # fit GP to simulations
+
     gp = mogp_emulator.GaussianProcess(input_points, results)
     gp.learn_hyperparameters()
 
     # We can now make predictions for a large number of input points much
     # more quickly than running the simulation.
-    query_points = ed.sample(1000)
+
+    query_points = ed.sample(analysis_points)
     predictions = gp.predict(query_points)
 
-    # predictions contains both the mean values and variances from the
-    # approximate model, so we can use this to quantify uncertainty given
-    # a known value of the moment.
-    # Since I don't have an actual observation to use, I will do a synthetic
-    # test by running an additional point so I can evaluate the results from
-    # the known inputs.
-    if not exists(join(results_dir, "data")):
-        makedirs(join(results_dir, "data"))
-    if not exists(join(results_dir, "problems")):
-        makedirs(join(results_dir, "problems"))
+    # set up history matching
 
-    known_input = ed.sample(1)
-    name = "known_value"
-    create_problem(known_input[0], name=name, output_dir=results_dir)
-    run_simulation(name=name, n_proc=4, mpi_exec=mpi_exec,
-                   fdfault_exec=fdfault_exec, output_dir=results_dir)
-    known_value = compute_moment(name=name, results_dir=results_dir)
-
-    # One easy method for comparing a model with observations is known as
-    # History Matching, where you compute an implausibility measure for many
-    # sample points given all sources of uncertainty (observational error,
-    # approximate model uncertainty, and "model discrepancy" which is a measure
-    # of how good the model is at describing reality). For simplicity here we
-    # will only consider the approximate model uncertainty, but for real
-    # situations it is important to include all three sources.
-    # The implausibility is then just the number of standard deviations between
-    # the predicted value and the known value.
-
-    # To compute the implausibility, we use the HistoryMatching class, which
-    # requires the observation, query points (coords), and predicted values
-    # (expectations), plus a threshold above which we can rule out a point
-
-    hm = mogp_emulator.HistoryMatching(obs=known_value, coords=query_points,
-                                       expectations=predictions, threshold=2.)
+    hm = mogp_emulator.HistoryMatching(obs=known_value, expectations=predictions,
+                                       threshold=threshold)
 
     implaus = hm.get_implausibility()
+    NROY = hm.get_NROY()
 
-    # We can see which points have not been ruled out yet (NROY) based on the
-    # implausibility threshold.
-
-    print("Actual point:", known_input[0])
-    print("NROY:")
-    print(query_points[hm.get_NROY()])
+    # make some plots
 
 
 if __name__ == "__main__":
@@ -137,10 +105,24 @@ if __name__ == "__main__":
             print("Error : input sample points should be integer value !")
             exit()
 
-        run_mogp_simulation(mpi_exec, fdfault_exec, results_dir)
-    elif mood == "analysis":
-        mpi_exec = sys.argv[2]
-        fdfault_exec = sys.argv[3]
-        results_dir = sys.argv[4]
+        run_fdfault_simulation(mpi_exec, fdfault_exec, results_dir)
 
-        run_mogp_analysis(mpi_exec, fdfault_exec, results_dir)
+    elif mood == "analysis":
+        try:
+            analysis_points = int(sys.argv[2])
+        except ValueError:
+            print("Error: number of analysis points must be an integer")
+            exit()
+        try:
+            known_value = float(sys.argv[3])
+        except ValueError:
+            print("Error: known value must be a float")
+            exit()
+        try:
+            threshold = float(sys.argv[4])
+        except ValueError:
+            print("Error: threshold must be a float")
+            exit()
+        results_dir = sys.argv[5]
+
+        run_mogp_analysis(analysis_points, known_value, threshold, results_dir)

--- a/config_files/demo/mogp_functions.py
+++ b/config_files/demo/mogp_functions.py
@@ -64,7 +64,7 @@ def load_results(results_dir):
 
     return input_points, results, ed
 
-def run_mogp_analysis(analysis_points, known_value, threshold, results_dir):
+def run_mogp_analysis(analysis_samples, known_value, threshold, results_dir):
 
     input_points, results, ed = load_results(results_dir)
 
@@ -76,8 +76,8 @@ def run_mogp_analysis(analysis_points, known_value, threshold, results_dir):
     # We can now make predictions for a large number of input points much
     # more quickly than running the simulation.
 
-    query_points = ed.sample(analysis_points)
-    predictions = gp.predict(query_points)
+    analysis_points = ed.sample(analysis_samples)
+    predictions = gp.predict(analysis_points)
 
     # set up history matching
 
@@ -131,9 +131,9 @@ if __name__ == "__main__":
 
     elif mood == "analysis":
         try:
-            analysis_points = int(sys.argv[2])
+            analysis_samples = int(sys.argv[2])
         except ValueError:
-            print("Error: number of analysis points must be an integer")
+            print("Error: number of analysis samples must be an integer")
             exit()
         try:
             known_value = float(sys.argv[3])
@@ -147,4 +147,4 @@ if __name__ == "__main__":
             exit()
         results_dir = sys.argv[5]
 
-        run_mogp_analysis(analysis_points, known_value, threshold, results_dir)
+        run_mogp_analysis(analysis_samples, known_value, threshold, results_dir)

--- a/config_files/demo/mogp_functions.py
+++ b/config_files/demo/mogp_functions.py
@@ -89,6 +89,28 @@ def run_mogp_analysis(analysis_points, known_value, threshold, results_dir):
 
     # make some plots
 
+    plt.figure()
+    plt.plot(analysis_points[NROY, 0], analysis_points[NROY, 1], 'o')
+    plt.xlabel('Normal Stress (MPa)')
+    plt.ylabel('Shear to Normal Stress Ratio')
+    plt.xlim((-120., -80.))
+    plt.ylim((0.1, 0.4))
+    plt.title("NROY Points")
+    plt.savefig("results/nroy.png")
+
+    import matplotlib.tri
+
+    plt.figure()
+    tri = matplotlib.tri.Triangulation(-(analysis_points[:,0]-80.)/40., (analysis_points[:,1]-0.1)/0.3)
+    plt.tripcolor(analysis_points[:,0], analysis_points[:,1], tri.triangles, implaus,
+                  vmin = 0., vmax = 6., cmap="viridis_r")
+    cb = plt.colorbar()
+    cb.set_label("Implausibility")
+    plt.xlabel('Normal Stress (MPa)')
+    plt.ylabel('Shear to Normal Stress Ratio')
+    plt.title("Implausibility Metric")
+    plt.savefig("results/implausibility.png")
+
 
 if __name__ == "__main__":
 

--- a/fabmogp.py
+++ b/fabmogp.py
@@ -13,7 +13,7 @@ add_local_paths("fabmogp")
 
 
 @task
-def mogp(config, **args):
+def mogp(config, seed=0, **args):
     """
     Submit a single mogp job to the remote queue.
     The job results will be stored with a name pattern as defined in the environment,
@@ -24,11 +24,13 @@ def mogp(config, **args):
     env.mood = "run_simulation"
     if (hasattr(env, 'sample_points') == False):
         env.sample_points = 1
+    env.seed = seed
 
-    local("python3 %s/init_config.py --sample_points %s --results_dir %s " %
+    local("python3 %s/init_config.py --sample_points %s --results_dir %s --seed %s" %
           (env.job_config_path_local,
            env.sample_points,
-           env.job_config_path_local)
+           env.job_config_path_local,
+           env.seed)
           )
     execute(put_configs, config)
 
@@ -36,7 +38,7 @@ def mogp(config, **args):
 
 
 @task
-def mogp_ensemble(config, sample_points=1, script='mogp', **args):
+def mogp_ensemble(config, sample_points=1, seed=0, script='mogp', **args):
     """
     Submits an ensemble of mogp jobs.
     One job is run for each file in <config_file_directory>/SWEEP.
@@ -48,6 +50,7 @@ def mogp_ensemble(config, sample_points=1, script='mogp', **args):
     sweep_dir = path_to_config + "/SWEEP"
     env.script = script
     env.sample_points = sample_points
+    env.seed = seed
     env.mood = "run_simulation"
 
     # clean SWEEP directory
@@ -57,17 +60,18 @@ def mogp_ensemble(config, sample_points=1, script='mogp', **args):
         folder_name = "sample_point_" + str(i)
         local("mkdir -p %s/%s" % (sweep_dir, folder_name))
 
-    local("python3 %s/init_config.py --sample_points %s --results_dir %s --isSWEEP True" %
+    local("python3 %s/init_config.py --sample_points %s --results_dir %s --isSWEEP True --seed %s" %
           (env.job_config_path_local,
            env.sample_points,
-           env.job_config_path_local)
+           env.job_config_path_local,
+           env.seed)
           )
 
     run_ensemble(config, sweep_dir, **args)
 
 
 @task
-def mogp_analysis(config, results_dir):
+def mogp_analysis(config, results_dir, analysis_points=10000, known_value=58., threshold=3.):
     """
     run : fab localhost mogp_analysis:demo,demo_localhost_16
 
@@ -76,8 +80,12 @@ def mogp_analysis(config, results_dir):
     """
     with_config(config)
     env.mood = "run_simulation"
+    env.analysis_points = analysis_points
+    env.known_value = known_value
+    env.threshold = threshold
 
-    local("python3 %s/run.py analysis %s  %s  %s/%s " %
+    local("python3 %s/mogp_functions.py analysis %s  %s  %s %s/%s " %
           (env.job_config_path_local,
-           env.mpi_exec, env.fdfault_exec,
+           env.analysis_points, env.known_value,
+           env.threshold,
            env.local_results, results_dir))

--- a/templates/mogp
+++ b/templates/mogp
@@ -7,4 +7,4 @@ $run_prefix
 
 /usr/bin/env > env.log
 
-python3 run.py $mood $mpi_exec $fdfault_exec $job_results $sample_points  
+python3 mogp_functions.py $mood $mpi_exec $fdfault_exec $job_results $sample_points


### PR DESCRIPTION
Refactor of the python functions to set up the simulations and run the analysis:

* Rename `run.py` to `mogp_functions.py` for clarity.
* Move commands to load results outside of the analysis function to enable users to load results manually.
* Rename `run_mogp_simulation` to `run_fdfault_simulation` to be more accurate.
* Change `run_mogp_analysis` function to take parameter arguments for number of analysis points, known seismic moment, implausibility threshold, and random seed. These parameters can be set when running the fabsim command in the shell.
* Allow init_config.py to specify the random seed from command line and the fabsim commands
